### PR TITLE
fix: update Response::getHeader parameter declaration

### DIFF
--- a/src/Server/Response.php
+++ b/src/Server/Response.php
@@ -123,7 +123,7 @@ class Response
      *
      * @return mixed
      */
-    public function getHeader(string $name = null): mixed
+    public function getHeader(null|string $name = null): mixed
     {
         if (!$name) {
             return $this->headers;


### PR DESCRIPTION
Update the parameter declaration in Response::getHeader method to use string|null type instead of ?string with default value to avoid PHP 8.1+ deprecation warning while maintaining backward compatibility.

This resolves the warning:
"Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead"